### PR TITLE
Create custom 6.2.7 redis image for redisgraph/search

### DIFF
--- a/bitnami/redis/6.2/debian-11/Dockerfile
+++ b/bitnami/redis/6.2/debian-11/Dockerfile
@@ -1,3 +1,5 @@
+FROM redislabs/redisgraph:2.8.20 AS graphmodule
+FROM redislabs/redisearch:2.4.16 AS searchmodule
 FROM docker.io/bitnami/minideb:bullseye
 
 ARG TARGETARCH
@@ -18,7 +20,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl libssl1.1 procps
+RUN install_packages ca-certificates curl libssl1.1 procps libgomp1
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "wait-for-port-1.0.5-1-linux-${OS_ARCH}-debian-11" \
@@ -46,6 +48,10 @@ RUN /opt/bitnami/scripts/redis/postunpack.sh
 ENV APP_VERSION="6.2.7" \
     BITNAMI_APP_NAME="redis" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/redis/bin:$PATH"
+
+RUN mkdir /opt/bitnami/redis/modules
+COPY --from=graphmodule /usr/lib/redis/modules/redisgraph.so* /opt/bitnami/redis/modules
+COPY --from=searchmodule /usr/lib/redis/modules/redisearch.so* /opt/bitnami/redis/modules
 
 EXPOSE 6379
 


### PR DESCRIPTION
This is a change to bitnami's standard redis image. Here we add redisgraph and redisearch modules as well as the required library in order to run on a DEBIAN os. We want to do this so that our image works with bitnami's other customizations since we will be deploying it using their helm chart.

```
redis version 6.2.7
redisgraph version 2.8.20
redisearch version 2.4.16
```
I have tested this with our Asserts helm chart and the new asserts-server code to support RedisGraph 2.8.x. Checked in standalone architecture as well as sentinel mode. Failovers work smoothly. Can do more testing once a migration and deployment plan for the cloud is in place. Just need the image as a first step.